### PR TITLE
fix: use arch instead of os for allocator

### DIFF
--- a/packages/pros-core/src/allocator/mod.rs
+++ b/packages/pros-core/src/allocator/mod.rs
@@ -1,6 +1,6 @@
 //! Simple allocator using the VEX libc allocation functions in vexos and jemalloc in the sim.
 
-#[cfg(target_os = "vexos")]
+#[cfg(target_arch = "arm")]
 mod vexos;
 #[cfg(target_arch = "wasm32")]
 mod wasm;


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This change is a step in updating cargo-pros to use the "none" OS in its target file, which is required to get certain compiler builtins to generate like `fmaxf`.

## Additional Context
- I have tested these changes on a VEX V5 brain.
<!--
Move all applicable items out of the comment:
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
