### PR TITLE
chore: bump versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ Before releasing:
 ## [Unreleased]
 
 ### Added
+
+### Fixed
+
+### Changed
+
+### Removed
+
+## [0.9.0]
+
+### Added
 - New Motor API (**Breaking Change**) (#66)
   - Added `MotorControl` enum for controlling motor targets (#66).
   - Added support for onboard velocity and position control in motors (#66).
@@ -229,3 +239,4 @@ Before releasing:
 [0.6.0]: https://github.com/pros-rs/pros-rs/compare/v0.5.0...v0.6.0
 [0.7.0]: https://github.com/pros-rs/pros-rs/compare/v0.6.0...v0.7.0
 [0.8.0]: https://github.com/pros-rs/pros-rs/compare/v0.7.0...v0.8.0
+[0.8.0]: https://github.com/pros-rs/pros-rs/compare/v0.8.0...v0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,7 +233,7 @@ Before releasing:
 
 ### Removed
 
-[unreleased]: https://github.com/pros-rs/pros-rs/compare/v0.8.0...HEAD
+[unreleased]: https://github.com/pros-rs/pros-rs/compare/v0.9.0...HEAD
 [0.4.0]: https://github.com/pros-rs/pros-rs/releases/tag/v0.4.0
 [0.5.0]: https://github.com/pros-rs/pros-rs/compare/v0.4.0...v0.5.0
 [0.6.0]: https://github.com/pros-rs/pros-rs/compare/v0.5.0...v0.6.0

--- a/packages/pros-async/Cargo.toml
+++ b/packages/pros-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pros-async"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "A simple async executor for pros-rs"
@@ -23,7 +23,7 @@ authors = [
 async-task = { version = "4.5.0", default-features = false }
 pros-core = { version = "0.1.0", path = "../pros-core" }
 waker-fn = "1.1.1"
-pros-sys = { version = "0.7.0", path = "../pros-sys" }
+pros-sys = { version = "0.8.0", path = "../pros-sys" }
 
 [lints]
 workspace = true

--- a/packages/pros-core/Cargo.toml
+++ b/packages/pros-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pros-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 description = "Core functionality for pros-rs"
@@ -20,7 +20,7 @@ authors = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pros-sys = { version = "0.7.0", path = "../pros-sys" }
+pros-sys = { version = "0.8.0", path = "../pros-sys" }
 no_std_io = { version = "0.6.0", features = ["alloc"] }
 snafu = { version = "0.8.0", default-features = false, features = [
     "rust_1_61",

--- a/packages/pros-devices/Cargo.toml
+++ b/packages/pros-devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pros-devices"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "High level device for pros-rs"
@@ -21,7 +21,7 @@ authors = [
 
 [dependencies]
 pros-core = { version = "0.1.0", path = "../pros-core" }
-pros-sys = { path = "../pros-sys", version = "0.7.0", features = ["xapi"] }
+pros-sys = { path = "../pros-sys", version = "0.8.0", features = ["xapi"] }
 snafu = { version = "0.8.0", default-features = false, features = [
     "rust_1_61",
     "unstable-core-error",

--- a/packages/pros-panic/Cargo.toml
+++ b/packages/pros-panic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pros-panic"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 description = "Panic handler for pros-rs"
@@ -20,8 +20,8 @@ authors = [
 
 [dependencies]
 pros-core = { version = "0.1.0", path = "../pros-core" }
-pros-devices = { version = "0.1.0", path = "../pros-devices", optional = true }
-pros-sys = { version = "0.7.0", path = "../pros-sys" }
+pros-devices = { version = "0.2.0", path = "../pros-devices", optional = true }
+pros-sys = { version = "0.8.0", path = "../pros-sys" }
 
 [features]
 default = ["display_panics"]

--- a/packages/pros-sync/Cargo.toml
+++ b/packages/pros-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pros-sync"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "`SyncRobot` trait and macro for pros-rs"

--- a/packages/pros-sys/Cargo.toml
+++ b/packages/pros-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pros-sys"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "EFI for the PROS rust bindings"
 keywords = ["PROS", "Robotics", "bindings", "vex", "v5"]

--- a/packages/pros/Cargo.toml
+++ b/packages/pros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pros"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Rust bindings for PROS"
 keywords = ["PROS", "Robotics", "bindings", "vex", "v5"]
@@ -18,13 +18,13 @@ rust-version = "1.75.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pros-sync = { version = "0.1.0", path = "../pros-sync", optional = true }
-pros-async = { version = "0.1.0", path = "../pros-async", optional = true }
-pros-devices = { version = "0.1.0", path = "../pros-devices", optional = true }
-pros-panic = { version = "0.1.0", path = "../pros-panic", optional = true }
+pros-sync = { version = "0.2.0", path = "../pros-sync", optional = true }
+pros-async = { version = "0.2.0", path = "../pros-async", optional = true }
+pros-devices = { version = "0.2.0", path = "../pros-devices", optional = true }
+pros-panic = { version = "0.1.1", path = "../pros-panic", optional = true }
 pros-core = { version = "0.1.0", path = "../pros-core", optional = true }
 pros-math = { version = "0.1.0", path = "../pros-math", optional = true }
-pros-sys = { version = "0.7.0", path = "../pros-sys" }
+pros-sys = { version = "0.8.0", path = "../pros-sys" }
 
 [features]
 default = ["async", "devices", "panic", "display_panics", "core", "math"]

--- a/packages/pros/Cargo.toml
+++ b/packages/pros/Cargo.toml
@@ -22,7 +22,7 @@ pros-sync = { version = "0.2.0", path = "../pros-sync", optional = true }
 pros-async = { version = "0.2.0", path = "../pros-async", optional = true }
 pros-devices = { version = "0.2.0", path = "../pros-devices", optional = true }
 pros-panic = { version = "0.1.1", path = "../pros-panic", optional = true }
-pros-core = { version = "0.1.0", path = "../pros-core", optional = true }
+pros-core = { version = "0.1.1", path = "../pros-core", optional = true }
 pros-math = { version = "0.1.0", path = "../pros-math", optional = true }
 pros-sys = { version = "0.8.0", path = "../pros-sys" }
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This pr updates pros-rs to 0.9.0. The, hopefull, final version of pros-rs.

## Additional Context
- These are *only* non-code changes (e.g. documentation, README.md).
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).

- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
