### PR TITLE
docs: direct users to vexide instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Pros-rs
 
-Work in progress opinionated Rust bindings for the [PROS](https://github.com/purduesigbots/pros) library and kernel.
+Opinionated Rust bindings for the [PROS](https://github.com/purduesigbots/pros) library and kernel.
 
-This project is still early in development.
-Make sure to check out the todo list [(TODO.md)](TODO.md)
+> [!IMPORTANT]
+>
+> This project is not currently in development. If this looks interesting to you, check out [`vexide`](https://github.com/vexide/vexide) instead!
 
 ## Usage
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Directs users to Vexide so they know that there is still development going on, somewhere!

## Additional Context
- These are *only* non-code changes (e.g. documentation, README.md).
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
