### PR TITLE
Remove references to active development

### DIFF
--- a/packages/pros/src/lib.rs
+++ b/packages/pros/src/lib.rs
@@ -5,7 +5,6 @@
 //! Advantages over similar libraries or PROS itself:
 //! - Pros-rs has an [`Async executor`](async_runtime) which allows for easy and performant asynchronous code.
 //! - Simulation support with [`pros-simulator`](https://crates.io/crates/pros-simulator) and any interface with it (e.g. [`pros-simulator-gui`](https://github.com/pros-rs/pros-simulator-gui))
-//! - Active development. Pros-rs is actively developed and maintained.
 //! - Pros-rs is a real crate on crates.io instead of a template, or similar. This allows for dependency management with cargo.
 //!
 //! # Usage


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
pros-rs is no longer actively maintained, and furthermore, this point was originally inaccurate because PROS is and has always been actively maintained. Therefore, this PR removes references to pros-rs being under active development as an advantage.
## Additional Context
- These are *only* non-code changes (e.g. documentation, README.md).
- This PR is essentially the same as https://github.com/vexide/vexide/pull/60
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
